### PR TITLE
Add support for named instances

### DIFF
--- a/lib/create-manager.js
+++ b/lib/create-manager.js
@@ -262,6 +262,7 @@ module.exports = {
           _mssqlClientConfig.database = _databaseName;
         }
         if (_instanceName) {
+          _mssqlClientConfig.options = _mssqlClientConfig.options || {};
           _mssqlClientConfig.options.instanceName = _instanceName;
         }
       }

--- a/lib/create-manager.js
+++ b/lib/create-manager.js
@@ -244,15 +244,25 @@ module.exports = {
         }
       }
 
-      // Parse database name
+      // Parse instance and database names
       if (_.isString(parsedConnectionStr.pathname)) {
-        var _databaseName = parsedConnectionStr.pathname;
-        // Trim leading and trailing slashes
-        _databaseName = _databaseName.replace(/^\/+/, '');
-        _databaseName = _databaseName.replace(/\/+$/, '');
+        // Check if a named instance is specified in url as /instance/database
+        if (parsedConnectionStr.pathname.match(/\/.+\/.+/)) {
+          var _instanceName = parsedConnectionStr.pathname.split(/\//)[1];
+          var _databaseName = parsedConnectionStr.pathname.split(/\//)[2];
+        }
+        else {
+          var _databaseName = parsedConnectionStr.pathname;
+          // Trim leading and trailing slashes
+          _databaseName = _databaseName.replace(/^\/+/, '');
+          _databaseName = _databaseName.replace(/\/+$/, '');
+        }
         // If anything is left, use it as the database name.
         if (_databaseName) {
           _mssqlClientConfig.database = _databaseName;
+        }
+        if (_instanceName) {
+          _mssqlClientConfig.options.instanceName = _instanceName;
         }
       }
     } catch (_e) {
@@ -261,11 +271,6 @@ module.exports = {
         error: _e,
         meta: inputs.meta
       });
-    }
-
-    // Set instance name if configured in inputs.meta
-    if (inputs.meta.instanceName && inputs.meta.instanceName.match(/^.+$/)) {
-      _mssqlClientConfig.options.instanceName = inputs.meta.instanceName;
     }
 
     // Create a connection pool.

--- a/lib/create-manager.js
+++ b/lib/create-manager.js
@@ -263,6 +263,11 @@ module.exports = {
       });
     }
 
+    // Set instance name if configured in inputs.meta
+    if (inputs.meta.instanceName && inputs.meta.instanceName.match(/^.+$/)) {
+      _mssqlClientConfig.options.instanceName = inputs.meta.instanceName;
+    }
+
     // Create a connection pool.
     //
     // More about using pools with node-mssql:


### PR DESCRIPTION
Fixes #5. This may not be how you'd like to implement it, but I thought I'd open this to provide a baseline example of how I did it.

I can now configure the sails datastore like below:


```javascript
module.exports = {
    datastores: {
        sqlserver: {
            adapter: require('sails-mssql'),
            url: 'mssql://user:password@host:port/database',
            instanceName: 'my_instance'
        }
    }
} 
```