### PR TITLE
Added requestTimeout and pool config

### DIFF
--- a/lib/create-manager.js
+++ b/lib/create-manager.js
@@ -174,12 +174,12 @@ module.exports = {
         'server',
 
         // Advanced:
-        'connectTimeout', 'stringifyObjects', 'insecureAuth', 'typeCast',
+        'connectTimeout', 'requestTimeout', 'stringifyObjects', 'insecureAuth', 'typeCast',
         'queryFormat', 'supportBigNumbers', 'bigNumberStrings', 'dateStrings',
         'debug', 'trace', 'multipleStatements', 'flags', 'options',
 
         // Pool-specific:
-        'acquireTimeout', 'waitForConnections', 'connectionLimit', 'queueLimit',
+        'pool',
 
       ].forEach(function processKey(mssqlClientConfKeyName) {
         if (!_.isUndefined(inputs.meta[mssqlClientConfKeyName])) {


### PR DESCRIPTION
Changed `create-manager.js` to add some important configs for `mssql.ConnectionPool`:

- _requestTimeout_: Request timeout in ms (have some queries that takes longer than the default, 15 seconds)
- _pool_: Allows to configure min, max and idleTimeoutMillis for connection pool management.

See https://www.npmjs.com/package/mssql#general-same-for-all-drivers